### PR TITLE
feat: add sandboxed bash command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ end
 | `mkdir <dir>`             | Create directory                      |
 | `rm <file>`               | Remove file                           |
 | `cp <src> <dest>`         | Copy file                             |
+| `bash -c "<script>"`      | Run a bash-like script in sandbox     |
 | `env [VAR] [VAR=value]`   | Display or set environment variables  |
 | `help [command]`          | Show available commands               |
 | `sleep <seconds>`         | Sleep for duration                    |

--- a/lib/jido/shell/command/bash.ex
+++ b/lib/jido/shell/command/bash.ex
@@ -1,0 +1,75 @@
+defmodule Jido.Shell.Command.Bash do
+  @moduledoc """
+  Executes bash-like scripts in the Jido.Shell sandbox.
+
+  Scripts are executed through Jido.Shell commands (not the host shell).
+
+  ## Usage
+
+      bash -c "mkdir docs; write docs/hello.txt hello; cat docs/hello.txt"
+      bash /scripts/setup.sh
+  """
+
+  @behaviour Jido.Shell.Command
+
+  alias Jido.Shell.Sandbox.Bash, as: BashSandbox
+
+  @impl true
+  def name, do: "bash"
+
+  @impl true
+  def summary, do: "Run a bash-like script in the shell sandbox"
+
+  @impl true
+  def schema do
+    Zoi.map(%{
+      args: Zoi.array(Zoi.string()) |> Zoi.default([])
+    })
+  end
+
+  @impl true
+  def run(state, args, emit) do
+    with {:ok, script} <- load_script(state, args.args),
+         {:ok, final_state} <- BashSandbox.execute(state, script, emit) do
+      to_state_update(state, final_state)
+    end
+  end
+
+  defp load_script(_state, []),
+    do: {:error, Jido.Shell.Error.validation("bash", [%{message: "usage: bash -c \"<script>\" | bash <file>"}])}
+
+  defp load_script(_state, ["-c"]),
+    do: {:error, Jido.Shell.Error.validation("bash", [%{message: "usage: bash -c \"<script>\" | bash <file>"}])}
+
+  defp load_script(_state, ["-c", script]), do: {:ok, script}
+
+  defp load_script(_state, ["-c" | _]),
+    do: {:error, Jido.Shell.Error.validation("bash", [%{message: "usage: bash -c \"<script>\" | bash <file>"}])}
+
+  defp load_script(state, [path]) do
+    path = resolve_path(state.cwd, path)
+    Jido.Shell.VFS.read_file(state.workspace_id, path)
+  end
+
+  defp load_script(_state, _),
+    do: {:error, Jido.Shell.Error.validation("bash", [%{message: "usage: bash -c \"<script>\" | bash <file>"}])}
+
+  defp to_state_update(state, final_state) do
+    state_update =
+      %{}
+      |> maybe_put(:cwd, state.cwd, final_state.cwd)
+      |> maybe_put(:env, state.env, final_state.env)
+
+    if map_size(state_update) == 0 do
+      {:ok, nil}
+    else
+      {:ok, {:state_update, state_update}}
+    end
+  end
+
+  defp maybe_put(acc, _key, left, right) when left == right, do: acc
+  defp maybe_put(acc, key, _left, right), do: Map.put(acc, key, right)
+
+  defp resolve_path(_cwd, "/" <> _ = path), do: Path.expand(path)
+  defp resolve_path(cwd, path), do: Path.join(cwd, path) |> Path.expand()
+end

--- a/lib/jido/shell/command/registry.ex
+++ b/lib/jido/shell/command/registry.ex
@@ -37,6 +37,7 @@ defmodule Jido.Shell.Command.Registry do
       "cd" => Jido.Shell.Command.Cd,
       "mkdir" => Jido.Shell.Command.Mkdir,
       "write" => Jido.Shell.Command.Write,
+      "bash" => Jido.Shell.Command.Bash,
       "sleep" => Jido.Shell.Command.Sleep,
       "seq" => Jido.Shell.Command.Seq,
       "help" => Jido.Shell.Command.Help,

--- a/lib/jido/shell/sandbox/bash.ex
+++ b/lib/jido/shell/sandbox/bash.ex
@@ -1,0 +1,68 @@
+defmodule Jido.Shell.Sandbox.Bash do
+  @moduledoc """
+  Executes bash-like scripts by dispatching each statement through the
+  existing Jido.Shell command system.
+
+  This keeps execution sandboxed to registered Jido.Shell commands and
+  Jido.Shell.VFS-backed file operations.
+  """
+
+  alias Jido.Shell.CommandRunner
+  alias Jido.Shell.Session.State
+
+  @type execute_result :: {:ok, State.t()} | {:error, Jido.Shell.Error.t()} | {:error, term()}
+
+  @doc """
+  Executes a script in the current session context.
+
+  Script lines are split on newlines and `;`, with blank lines and full-line
+  comments (`# ...`) ignored.
+  """
+  @spec execute(State.t(), String.t(), Jido.Shell.Command.emit()) :: execute_result()
+  def execute(%State{} = state, script, emit) when is_binary(script) do
+    script
+    |> statements()
+    |> run_statements(state, emit)
+  end
+
+  @doc """
+  Returns normalized script statements.
+  """
+  @spec statements(String.t()) :: [String.t()]
+  def statements(script) when is_binary(script) do
+    script
+    |> String.split(~r/\r?\n/)
+    |> Enum.flat_map(&String.split(&1, ";"))
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&skip_statement?/1)
+  end
+
+  defp run_statements([], state, _emit), do: {:ok, state}
+
+  defp run_statements([line | rest], state, emit) do
+    case CommandRunner.execute(state, line, emit) do
+      {:ok, {:state_update, changes}} ->
+        run_statements(rest, apply_state_updates(state, changes), emit)
+
+      {:ok, _} ->
+        run_statements(rest, state, emit)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp apply_state_updates(state, changes) do
+    Enum.reduce(changes, state, fn {key, value}, acc ->
+      case key do
+        :cwd -> State.set_cwd(acc, value)
+        :env -> %{acc | env: value}
+        _ -> acc
+      end
+    end)
+  end
+
+  defp skip_statement?(""), do: true
+  defp skip_statement?(<<"#", _::binary>>), do: true
+  defp skip_statement?(_), do: false
+end

--- a/test/jido/shell/command/bash_test.exs
+++ b/test/jido/shell/command/bash_test.exs
@@ -1,0 +1,138 @@
+defmodule Jido.Shell.Command.BashTest do
+  use Jido.Shell.Case, async: false
+
+  alias Jido.Shell.Command.Bash
+  alias Jido.Shell.Session
+  alias Jido.Shell.Session.State
+  alias Jido.Shell.SessionServer
+  alias Jido.Shell.VFS
+
+  setup do
+    VFS.init()
+    workspace_id = :"bash_ws_#{System.unique_integer([:positive])}"
+    fs_name = :"bash_fs_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      {Jido.VFS.Adapter.InMemory, {Jido.VFS.Adapter.InMemory, %Jido.VFS.Adapter.InMemory.Config{name: fs_name}}}
+    )
+
+    :ok = VFS.mount(workspace_id, "/", Jido.VFS.Adapter.InMemory, name: fs_name)
+
+    {:ok, state} = State.new(%{id: "test", workspace_id: workspace_id, cwd: "/"})
+
+    on_exit(fn ->
+      VFS.unmount(workspace_id, "/")
+    end)
+
+    {:ok, state: state, workspace_id: workspace_id}
+  end
+
+  describe "name/0" do
+    test "returns bash" do
+      assert Bash.name() == "bash"
+    end
+  end
+
+  describe "summary/0" do
+    test "returns a description" do
+      assert is_binary(Bash.summary())
+    end
+  end
+
+  describe "schema/0" do
+    test "returns a Zoi schema" do
+      schema = Bash.schema()
+      assert {:ok, %{args: []}} = Zoi.parse(schema, %{})
+      assert {:ok, %{args: ["-c", "echo hi"]}} = Zoi.parse(schema, %{args: ["-c", "echo hi"]})
+    end
+  end
+
+  describe "run/3" do
+    test "runs inline script with state updates", %{state: state} do
+      script = "mkdir docs; cd docs; write hello.txt hello; cat hello.txt"
+
+      {result, events} =
+        capture_events(fn emit ->
+          Bash.run(state, %{args: ["-c", script]}, emit)
+        end)
+
+      assert {:ok, {:state_update, %{cwd: "/docs"}}} = result
+      assert {:output, "wrote 5 bytes to /docs/hello.txt\n"} in events
+      assert {:output, "hello"} in events
+    end
+
+    test "runs script from vfs file", %{state: state, workspace_id: workspace_id} do
+      :ok = VFS.mkdir(workspace_id, "/scripts")
+
+      :ok =
+        VFS.write_file(
+          workspace_id,
+          "/scripts/setup.sh",
+          """
+          mkdir data
+          write data/a.txt alpha
+          ls data
+          """
+        )
+
+      {result, events} =
+        capture_events(fn emit ->
+          Bash.run(state, %{args: ["/scripts/setup.sh"]}, emit)
+        end)
+
+      assert {:ok, nil} = result
+      assert {:output, "wrote 5 bytes to /data/a.txt\n"} in events
+      assert {:output, "a.txt\n"} in events
+    end
+
+    test "returns error when script file does not exist", %{state: state} do
+      result = Bash.run(state, %{args: ["/scripts/missing.sh"]}, fn _event -> :ok end)
+
+      assert {:error, %Jido.Shell.Error{code: {:vfs, :not_found}}} = result
+    end
+
+    test "stops when script uses unsupported command", %{state: state} do
+      {result, events} =
+        capture_events(fn emit ->
+          Bash.run(state, %{args: ["-c", "echo ok; uname -a"]}, emit)
+        end)
+
+      assert {:output, "ok\n"} in events
+      assert {:error, %Jido.Shell.Error{code: {:shell, :unknown_command}}} = result
+    end
+  end
+
+  describe "integration with session" do
+    test "applies script state updates to session", %{workspace_id: workspace_id} do
+      {:ok, session_id} = Session.start(workspace_id)
+      :ok = SessionServer.subscribe(session_id, self())
+
+      :ok = SessionServer.run_command(session_id, "bash -c \"mkdir home; cd home\"")
+
+      assert_receive {:jido_shell_session, ^session_id, {:command_started, _}}
+      assert_receive {:jido_shell_session, ^session_id, {:cwd_changed, "/home"}}
+      assert_receive {:jido_shell_session, ^session_id, :command_done}
+
+      {:ok, state} = SessionServer.get_state(session_id)
+      assert state.cwd == "/home"
+    end
+  end
+
+  defp capture_events(fun) do
+    emit = fn event ->
+      send(self(), {:event, event})
+      :ok
+    end
+
+    result = fun.(emit)
+    {result, receive_all_events([])}
+  end
+
+  defp receive_all_events(acc) do
+    receive do
+      {:event, event} -> receive_all_events([event | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/jido/shell/command/registry_test.exs
+++ b/test/jido/shell/command/registry_test.exs
@@ -22,6 +22,7 @@ defmodule Jido.Shell.Command.RegistryTest do
       names = Registry.list()
       assert "echo" in names
       assert "pwd" in names
+      assert "bash" in names
     end
   end
 
@@ -31,6 +32,7 @@ defmodule Jido.Shell.Command.RegistryTest do
       assert is_map(commands)
       assert commands["echo"] == Jido.Shell.Command.Echo
       assert commands["pwd"] == Jido.Shell.Command.Pwd
+      assert commands["bash"] == Jido.Shell.Command.Bash
     end
   end
 end

--- a/test/jido/shell/sandbox/bash_test.exs
+++ b/test/jido/shell/sandbox/bash_test.exs
@@ -1,0 +1,73 @@
+defmodule Jido.Shell.Sandbox.BashTest do
+  use Jido.Shell.Case, async: false
+
+  alias Jido.Shell.Sandbox.Bash
+  alias Jido.Shell.Session.State
+  alias Jido.Shell.VFS
+
+  setup do
+    VFS.init()
+    workspace_id = :"sandbox_ws_#{System.unique_integer([:positive])}"
+    fs_name = :"sandbox_fs_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      {Jido.VFS.Adapter.InMemory, {Jido.VFS.Adapter.InMemory, %Jido.VFS.Adapter.InMemory.Config{name: fs_name}}}
+    )
+
+    :ok = VFS.mount(workspace_id, "/", Jido.VFS.Adapter.InMemory, name: fs_name)
+
+    {:ok, state} = State.new(%{id: "test", workspace_id: workspace_id, cwd: "/"})
+
+    on_exit(fn ->
+      VFS.unmount(workspace_id, "/")
+    end)
+
+    {:ok, state: state}
+  end
+
+  describe "statements/1" do
+    test "splits lines and semicolons and removes comments" do
+      script = """
+      # comment
+      echo one; echo two
+
+      pwd
+      """
+
+      assert Bash.statements(script) == ["echo one", "echo two", "pwd"]
+    end
+  end
+
+  describe "execute/3" do
+    test "executes statements through command runner", %{state: state} do
+      script = "echo hello\npwd"
+
+      {result, events} =
+        capture_events(fn emit ->
+          Bash.execute(state, script, emit)
+        end)
+
+      assert {:ok, %State{cwd: "/"}} = result
+      assert {:output, "hello\n"} in events
+      assert {:output, "/\n"} in events
+    end
+  end
+
+  defp capture_events(fun) do
+    emit = fn event ->
+      send(self(), {:event, event})
+      :ok
+    end
+
+    result = fun.(emit)
+    {result, receive_all_events([])}
+  end
+
+  defp receive_all_events(acc) do
+    receive do
+      {:event, event} -> receive_all_events([event | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a new built-in `bash` command for executing bash-like scripts in Jido.Shell
- execute scripts through existing registered commands via a new `Jido.Shell.Sandbox.Bash` executor (no host shell execution)
- support inline scripts (`bash -c "..."`) and VFS script files (`bash /path/to/script.sh`)
- add tests for command behavior, session state updates, and script statement parsing

## Why
Issue #3 requests bash execution support with sandbox behavior and Jido.VFS-backed operations. This implementation routes every script statement through the existing command registry/VFS path, which keeps execution constrained to shell-safe commands.

## Verification
- mix format
- mix test

Closes #3
