### PR TITLE
chore: normalize CI version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,11 @@ jobs:
   lint:
     name: Lint
     uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@main
-    with:
-      otp_version: "27"
-      elixir_version: "1.18"
 
   test:
     name: Test
     uses: agentjido/github-actions/.github/workflows/elixir-test.yml@main
     with:
-      otp_versions: '["26", "27"]'
-      elixir_versions: '["1.17", "1.18"]'
+      otp_versions: '["27", "28"]'
+      elixir_versions: '["1.18", "1.19"]'
       test_command: mix test


### PR DESCRIPTION
## What changed

- **Lint job**: Removed explicit `otp_version` and `elixir_version` overrides to use shared workflow defaults (OTP 28, Elixir 1.19).
- **Test job**: Updated version matrix from OTP 26+27 / Elixir 1.17+1.18 to OTP 27+28 / Elixir 1.18+1.19.

## Why

Align version matrix with the rest of the Jido repos and use shared workflow defaults for lint versions.