### PR TITLE
ci: test Elixir 1.20 rc5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       otp_versions: '["27", "28"]'
       elixir_versions: '["1.18", "1.19"]'
-      experimental_compile_elixir_versions: '["v1.20.0-rc.4"]'
+      experimental_compile_elixir_versions: '["v1.20.0-rc.5"]'
       experimental_compile_otp_versions: '["28.4.1"]'
       experimental_compile_otp_name: '28'
       credo_command: mix credo --min-priority higher


### PR DESCRIPTION
Updates the experimental compile-only Elixir lane from v1.20.0-rc.4 to v1.20.0-rc.5.

The stable test matrix remains on Elixir 1.18 and 1.19.